### PR TITLE
Fix RPC timeout handling: don’t block DAG after kicking slow RPC

### DIFF
--- a/backend/tests/test_load.py
+++ b/backend/tests/test_load.py
@@ -61,4 +61,4 @@ if __name__ == "__main__":
     
     args = parser.parse_args()
     
-    test_load_data(args.chain, args.start_block, args.batch_size, args.validate) 
+    test_load_data(args.chain, args.start_block, args.batch_size)


### PR DESCRIPTION
### What changed
- Monitor counts only threads for RPCs still in `active_rpcs` (excludes kicked ones)
- Skip joining threads for kicked RPCs; only join active ones
- Mark worker/manager threads as daemon so kicked workers can't hold up shutdown

### Why we were seeing the issue  
- When a timeout was detected, we "kicked" the RPC from rotation, but the monitor was still counting and waiting for that kicked RPC's worker thread, which could be stuck in a long call.

### Outcome
- Kicked RPCs no longer block the DAG (we don't wait for them)
- Active thread count reflects only usable RPCs (excludes kicked ones)
- We still wait for active RPCs to finish their work normally